### PR TITLE
Allow WM::Client ::TheSchwartz to pass DBI options

### DIFF
--- a/lib/WorkerManager/Client/TheSchwartz.pm
+++ b/lib/WorkerManager/Client/TheSchwartz.pm
@@ -13,13 +13,14 @@ sub new {
     my $dsn = $args->{dsn} || $args->{dns} || croak 'not specified dsn for worker manager';
     my $user = $args->{user} || 'nobody';
     my $pass = $args->{pass} || 'nobody';
+    my $opts = $args->{opts} || {};
 
     my $client;
     if ($ENV{DISABLE_WORKER}) {
         TheSchwartz->require;
         TheSchwartz::Job->require;
     } else {
-        my $dbh = DBI->connect($dsn, $user, $pass, {RaiseError => 1});
+        my $dbh = DBI->connect($dsn, $user, $pass, {RaiseError => 1, %$opts});
         $client = TheSchwartz::Simple->new([$dbh]);
     }
     bless { client => $client }, $class;

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -4,6 +4,8 @@ use Test::More;
 
 use_ok $_ for (qw(
     WorkerManager
+    WorkerManager::TheSchwartz
+    WorkerManager::Client::TheSchwartz
 ));
 
 done_testing;


### PR DESCRIPTION
To suppress "Duplicate entry" warnings when inserting with `uniqkey`, we have to pass `PrintError => 0` to `DBI->connect()`.