### PR TITLE
Fix child process check using documented method of ForkManager

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'DBI';
 requires 'File::Pid';
 requires 'Module::Load';
-requires 'Parallel::ForkManager';
+requires 'Parallel::ForkManager', '2.02';
 requires 'Proc::Daemon';
 requires 'TheSchwartz';
 requires 'TheSchwartz::Simple';

--- a/eg/workermanager.pl
+++ b/eg/workermanager.pl
@@ -134,5 +134,5 @@ $wm->main();
 $pid->remove if $pid;
 
 END {
-    $wm->killall_children() if !$DAEMON && ! $wm->{pm}->{in_child};
+    $wm->killall_children() if !$DAEMON && $wm->{pm}->is_parent;
 }

--- a/lib/WorkerManager.pm
+++ b/lib/WorkerManager.pm
@@ -112,7 +112,7 @@ sub set_signal_handlers {
 
         $self->{terminating} = 1;
         $self->{client}->terminate if $self->{client};
-        unless ($self->{pm}->is_child) {
+        if ($self->{pm}->is_parent) {
             $self->terminate_all_children;
         }
     };
@@ -127,7 +127,7 @@ sub set_signal_handlers {
 
         $self->{terminating} = 1;
         $self->{client}->terminate if $self->{client};
-        unless ($self->{pm}->is_child) {
+        if ($self->{pm}->is_parent) {
             $self->killall_children;
         }
         exit(1);

--- a/lib/WorkerManager.pm
+++ b/lib/WorkerManager.pm
@@ -112,7 +112,7 @@ sub set_signal_handlers {
 
         $self->{terminating} = 1;
         $self->{client}->terminate if $self->{client};
-        unless ($self->{pm}->{in_child}) {
+        unless ($self->{pm}->is_child) {
             $self->terminate_all_children;
         }
     };
@@ -127,7 +127,7 @@ sub set_signal_handlers {
 
         $self->{terminating} = 1;
         $self->{client}->terminate if $self->{client};
-        unless ($self->{pm}->{in_child}) {
+        unless ($self->{pm}->is_child) {
             $self->killall_children;
         }
         exit(1);


### PR DESCRIPTION
This is a fix for the problem that SIGINT is emitted at unexpected timing. The value `$self->{pm}->{in_child}` used to exist in old versions of Parallel::ForkManager (<2.0) but removed at https://github.com/dluxhu/perl-parallel-forkmanager/commit/d7b81f8ae947a94776ab003e269d1bdbc054a2f4. ~The package provides is_child method. See https://metacpan.org/pod/Parallel::ForkManager#is_child.~ I refactored `unless is_child` to `if is_parent`.