### PR TITLE
Use perl:5.10-buster in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.10'
+          - '5.10-buster'
           - latest
     container:
       image: perl:${{ matrix.perl-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,7 @@ jobs:
         run: perl -V
       - name: Install minilla
         run: cpanm -n Minilla
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: minil test
         run: minil test


### PR DESCRIPTION
`perl:5.10` uses a deprecated Docker image format and fails to run on GitHub Actions. Replacing it with `perl:5.10-buster` fixes the issue.

> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/perl:5.10 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/